### PR TITLE
fix: `RadioCardGroup` color

### DIFF
--- a/src/components/RadioCardGroup/RadioCardGroup.tsx
+++ b/src/components/RadioCardGroup/RadioCardGroup.tsx
@@ -1,4 +1,4 @@
-// Tremor Radio Card [v0.0.2]
+// Tremor Radio Card [v0.0.3]
 
 import React from "react"
 import * as RadioGroupPrimitives from "@radix-ui/react-radio-group"
@@ -64,7 +64,7 @@ const RadioCardIndicator = React.forwardRef<
         // base
         "relative flex size-4 shrink-0 appearance-none items-center justify-center rounded-full border shadow-sm outline-none",
         // border color
-        "border-gray-200 dark:border-gray-800",
+        "border-gray-300 dark:border-gray-800",
         // background color
         "bg-white dark:bg-gray-950",
         // checked

--- a/src/components/RadioCardGroup/changelog.md
+++ b/src/components/RadioCardGroup/changelog.md
@@ -1,5 +1,11 @@
 # Tremor Radio Card Group Changelog
 
+## 0.0.3
+
+### Changes
+
+- fix: RadioCard border color
+
 ## 0.0.2
 
 ### Changes


### PR DESCRIPTION
**Description**

This PR:

* Updates the border color of RadioCardGroup

**Related issue(s)**

<!--- Please link to the issue here: -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

**What kind of change does this PR introduce?** (check at least one)

<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature (BREAKING CHANGE which adds functionality)
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**How has this been tested?**

<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Screenshots (if appropriate):**

**The PR fulfils these requirements:**

- [x] It's submitted to the `main` branch
- [ ] Add refs #XXX or fixes #XXX to the related issue section if your PR refers to or fixes an issue.
- [x] My change requires a change to the documentation. (Managed by Tremor Team)
- [ ] I have added tests to cover my changes
- [ ] Check the ["Allow edits from maintainers" option](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) while creating your PR.
- [x] By contributing to Tremor, you confirm that you have read and agreed to Tremor's [CONTRIBUTING.md](https://github.com/tremorlabs/tremor/blob/main/CONTRIBUTING.md) guideline. You also agree that your contributions will be licensed under the [Apache License 2.0](https://github.com/tremorlabs/tremor-raw/blob/main/License) license.
